### PR TITLE
30 improved errors - 2nd part

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,12 +82,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.71"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,19 +300,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
-name = "env_logger"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,12 +346,6 @@ name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "iana-time-zone"
@@ -626,16 +601,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pretty_env_logger"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "865724d4dbe39d9f3dd3b52b88d859d66bcb2d6a0acfd5ea68a65fb66d4bdc1c"
-dependencies = [
- "env_logger",
- "log",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,15 +759,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -1094,11 +1050,8 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 name = "zom"
 version = "0.0.0"
 dependencies = [
- "anyhow",
  "clap",
  "inkwell",
- "log",
- "pretty_env_logger",
  "zom_codegen",
  "zom_common",
  "zom_compiler",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,4 @@ readme = "README.md"
 
 [workspace.dependencies]
 inkwell = { version = "0.2.0", default-features = false }
-log = "0.4.18"
-pretty_env_logger = "0.5.0"
-
 criterion = "0.5.0"

--- a/zom/Cargo.toml
+++ b/zom/Cargo.toml
@@ -13,9 +13,6 @@ readme.workspace = true
 
 [dependencies]
 clap = { version = "4.3.0", features = ["derive", "cargo"] }
-anyhow = { version = "1.0.71", default-features = false }
-log.workspace = true
-pretty_env_logger.workspace = true
 
 zom_compiler = { path = "../zom_compiler" }
 zom_codegen ={ path = "../zom_codegen" }

--- a/zom/src/main.rs
+++ b/zom/src/main.rs
@@ -3,8 +3,8 @@ use std::error::Error;
 use zom::{run_with_args, ExitStatus};
 
 fn main() -> Result<(), Box<dyn Error>> {
-    pretty_env_logger::try_init()
-        .expect("Error occurs at the initialization of pretty_env_logger.");
+    
+
     let status = match run_with_args(std::env::args_os()) {
         Ok(v) => v,
         Err(err) => {

--- a/zom/src/main.rs
+++ b/zom/src/main.rs
@@ -1,6 +1,8 @@
+use std::error::Error;
+
 use zom::{run_with_args, ExitStatus};
 
-fn main() -> Result<(), anyhow::Error> {
+fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::try_init()
         .expect("Error occurs at the initialization of pretty_env_logger.");
     let status = match run_with_args(std::env::args_os()) {

--- a/zom/src/main.rs
+++ b/zom/src/main.rs
@@ -1,9 +1,33 @@
-use std::error::Error;
+use std::thread;
+use std::{error::Error, backtrace::Backtrace};
+use std::panic;
+use std::backtrace::BacktraceStatus::*;
 
 use zom::{run_with_args, ExitStatus};
+use zom_common::error::ZomError;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    
+    panic::set_hook(Box::new(|panic_info| {
+        let thread = thread::current();
+        let backtrace = Backtrace::capture();
+        println!("{}", panic_info);
+
+        match backtrace.status() {
+            Captured => {
+                if let Some(name) = thread.name() {
+                    println!("thread '{}' {}", name, backtrace)
+                }else {
+                    println!("{}", backtrace);
+                }
+            }
+            Disabled => println!("note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace"),
+            Unsupported => println!("note: backtrace is not supported."),
+            _ => {}
+        }
+
+        let ice = ZomError::ice_error(panic_info.to_string());
+        println!("\n{}", ice);
+    }));
 
     let status = match run_with_args(std::env::args_os()) {
         Ok(v) => v,

--- a/zom/src/ops/bobj.rs
+++ b/zom/src/ops/bobj.rs
@@ -1,7 +1,7 @@
 use std::{
     fs,
     // mem,
-    path::PathBuf,
+    path::PathBuf, error::Error,
 };
 
 use anyhow::anyhow;
@@ -13,7 +13,7 @@ use zom_fe::{
     parser::{parse, ParserSettings, ParsingContext},
 };
 
-use crate::ExitStatus;
+use crate::{ExitStatus, err};
 
 #[derive(clap::Args, Debug, Clone)]
 pub struct Args {
@@ -38,7 +38,7 @@ pub struct Args {
     verbose: bool,
 }
 
-pub fn build(mut args: Args) -> Result<ExitStatus, anyhow::Error> {
+pub fn build(mut args: Args) -> Result<ExitStatus, Box<dyn Error>> {
     // default ouput_file to `output.o`, it's where because with `default_value_t`, that doesn't work.
     if args.output_file.is_none() {
         args.output_file = if args.emit_ir {
@@ -50,7 +50,7 @@ pub fn build(mut args: Args) -> Result<ExitStatus, anyhow::Error> {
 
     let source = match fs::read_to_string(&mut args.source_file) {
         Ok(src) => src,
-        Err(_) => return Err(anyhow!("Error while trying to read the source file.")),
+        Err(_) => return Err(err!("Error while trying to read the source file.")),
     };
 
     let mut lexer = Lexer::new(
@@ -60,7 +60,7 @@ pub fn build(mut args: Args) -> Result<ExitStatus, anyhow::Error> {
 
     let tokens = match lexer.make_tokens() {
         Ok(src) => src,
-        Err(err) => return Err(anyhow!(format!("\n{}\n", err))),
+        Err(err) => return Err(err!(fmt "\n{}\n", err)),
     };
 
     args.verbose.then(|| {
@@ -87,10 +87,10 @@ pub fn build(mut args: Args) -> Result<ExitStatus, anyhow::Error> {
             if rest.is_empty() {
                 _ast = parsed_ast;
             } else {
-                return Err(anyhow!("There is rest after parsing."));
+                return Err(err!("There is rest after parsing."));
             }
         }
-        Err(err) => return Err(anyhow!(format!("\n{}\n", err))),
+        Err(err) => return Err(err!(fmt "\n{}\n", err)),
     }
 
     args.verbose.then(|| {

--- a/zom/src/ops/bobj.rs
+++ b/zom/src/ops/bobj.rs
@@ -4,7 +4,6 @@ use std::{
     path::PathBuf, error::Error,
 };
 
-use anyhow::anyhow;
 use inkwell::{context::Context, passes::PassManager};
 // use zom_codegen::gen::CodeGen;
 // use zom_compiler::compiler::Compiler;

--- a/zom/src/ops/dev.rs
+++ b/zom/src/ops/dev.rs
@@ -1,11 +1,12 @@
 use anyhow::anyhow;
+use std::error::Error;
 use std::io::{stdout, Write};
 use zom_fe::lexer::Lexer;
 use zom_fe::parser::{parse, ParserSettings, ParsingContext};
 
-use crate::ExitStatus;
+use crate::{ExitStatus, err};
 
-pub fn dev() -> Result<ExitStatus, anyhow::Error> {
+pub fn dev() -> Result<ExitStatus, Box<dyn Error>> {
     println!("Development command.\n");
 
     let mut buffer =
@@ -26,7 +27,7 @@ pub fn dev() -> Result<ExitStatus, anyhow::Error> {
 
     let tokens = match lexer.make_tokens() {
         Ok(t) => t,
-        Err(err) => return Err(anyhow!(format!("{}", err))),
+        Err(err) => return Err(err!(fmt "{}", err)),
     };
 
     println!("tokens = {tokens:#?}");
@@ -45,7 +46,7 @@ pub fn dev() -> Result<ExitStatus, anyhow::Error> {
             println!("ast = {:#?}", ast);
             println!("toks_rest = {:?}", rest_toks);
         }
-        Err(err) => return Err(anyhow!(format!("{}", err))),
+        Err(err) => return Err(err!(fmt "{}", err)),
     }
 
     Ok(ExitStatus::Success)

--- a/zom/src/ops/dev.rs
+++ b/zom/src/ops/dev.rs
@@ -1,4 +1,3 @@
-use anyhow::anyhow;
 use std::error::Error;
 use std::io::{stdout, Write};
 use zom_fe::lexer::Lexer;

--- a/zom/src/ops/dev.rs
+++ b/zom/src/ops/dev.rs
@@ -9,7 +9,7 @@ pub fn dev() -> Result<ExitStatus, anyhow::Error> {
     println!("Development command.\n");
 
     let mut buffer =
-        String::from("func foo(bar: i16, baz: str) { foo(test, test); foo = 12; foo }");
+        String::from("func foo(bar: i16, baz: str) { foo(test, test); foo = 12; foo ");
 
     print!("input: ");
     stdout().flush().expect("ERR: Flush the output failed.");
@@ -29,7 +29,7 @@ pub fn dev() -> Result<ExitStatus, anyhow::Error> {
         Err(err) => return Err(anyhow!(format!("{}", err))),
     };
 
-    // println!("tokens = {tokens:#?}");
+    println!("tokens = {tokens:#?}");
 
     let mut parse_context = ParsingContext::new("<dev_cmd>.zom".to_owned(), buffer, tokens.clone());
 

--- a/zom/src/ops/gettarget.rs
+++ b/zom/src/ops/gettarget.rs
@@ -4,7 +4,7 @@ use crate::ExitStatus;
 
 use zom_compiler::target::get_target_triple;
 
-pub fn gettarget<'a>() -> Result<ExitStatus, Box<dyn Error>> {
+pub fn gettarget() -> Result<ExitStatus, Box<dyn Error>> {
     println!("Target: {}", get_target_triple());
 
     Ok(ExitStatus::Success)

--- a/zom/src/ops/gettarget.rs
+++ b/zom/src/ops/gettarget.rs
@@ -1,8 +1,10 @@
+use std::error::Error;
+
 use crate::ExitStatus;
 
 use zom_compiler::target::get_target_triple;
 
-pub fn gettarget() -> Result<ExitStatus, anyhow::Error> {
+pub fn gettarget<'a>() -> Result<ExitStatus, Box<dyn Error>> {
     println!("Target: {}", get_target_triple());
 
     Ok(ExitStatus::Success)

--- a/zom/src/ops/version.rs
+++ b/zom/src/ops/version.rs
@@ -1,6 +1,8 @@
+use std::error::Error;
+
 use crate::ExitStatus;
 
-pub fn version() -> Result<ExitStatus, anyhow::Error> {
+pub fn version() -> Result<ExitStatus, Box<dyn Error>> {
     print!("zomc {}", env!("CARGO_PKG_VERSION"));
 
     cfg!(debug_assertions).then(|| print!("in DEBUG binary"));

--- a/zom_common/src/error.rs
+++ b/zom_common/src/error.rs
@@ -187,7 +187,7 @@ impl ZomError {
     pub fn ice_error(details: String) -> ZomError {
         ZomError {
             location: None,
-            details: "internal compiler error:".to_owned() + &details,
+            details: "internal compiler error: ".to_owned() + &details,
             is_warning: false,
             help: None,
             notes: vec!(

--- a/zom_common/src/error.rs
+++ b/zom_common/src/error.rs
@@ -192,7 +192,7 @@ impl ZomError {
             help: None,
             notes: vec!(
             "the compiler unexpectedly panicked. this is a bug.",
-            "we would appreciate a bug report: https://github.com/zom-lang/zom/issues/new?labels=bug (TODO: change the link to the template.)", // TODO: When issue #46 is finished, replace with the link to the template.
+            "we would appreciate a bug report: https://github.com/zom-lang/zom/issues/new?assignees=&labels=C-bug%2C+I-ICE%2C+A-compiler&projects=&template=ice.md",
             format!("zomc {} ({} {}) running on {}",
                     env!("CARGO_PKG_VERSION"),
                     &commit_hash()[..7],

--- a/zom_common/src/token.rs
+++ b/zom_common/src/token.rs
@@ -211,6 +211,8 @@ pub enum TokenType {
 
     // Identifier
     Ident(String), // Identifier is a alphanumeric string
+
+    EOF,
 }
 impl TokenType {
     pub fn format_toks(tokens: Vec<TokenType>) -> String {
@@ -262,6 +264,8 @@ impl Display for TokenType {
             Pub => write!(f, "keyword `pub`"),
 
             Ident(_) => write!(f, "identifier"),
+
+            EOF => write!(f, "End of File")
         }
     }
 }

--- a/zom_fe/src/lexer.rs
+++ b/zom_fe/src/lexer.rs
@@ -181,6 +181,7 @@ impl<'a> Lexer<'a> {
                 ch => return Err(Self::illegal_char(self.clone(), ch)),
             }
         }
+        tokens.push(Token { tt: EOF, span: self.pos..=self.pos });
 
         Ok(tokens)
     }

--- a/zom_fe/src/parser.rs
+++ b/zom_fe/src/parser.rs
@@ -148,6 +148,10 @@ pub fn parse(
         let result = match &cur_token.tt {
             Func => parse_function(&mut rest, settings, context),
             Extern => parse_extern(&mut rest, settings, context),
+            EOF => {
+                rest.pop();
+                break;
+            },
             tt => err_et!(context, cur_token.clone(), vec![Func, Extern], tt)
             // Bad(Box::new(UnexpectedTokenError::from_context(
             //     context,

--- a/zom_fe/src/parser/block.rs
+++ b/zom_fe/src/parser/block.rs
@@ -17,19 +17,19 @@ use super::{
 use crate::parser::PartParsingResult::*;
 
 #[derive(PartialEq, Clone, Debug)]
-pub struct BlockCodeExpr {
+pub struct Block {
     pub code: Vec<Statement>,
     pub returned_expr: Option<Box<Expression>>,
     pub span: RangeInclusive<usize>,
 }
 
-impl_span!(BlockCodeExpr);
+impl_span!(Block);
 
 pub(super) fn parse_block(
     tokens: &mut Vec<Token>,
     settings: &mut ParserSettings,
     context: &mut ParsingContext,
-) -> PartParsingResult<BlockCodeExpr> {
+) -> PartParsingResult<Block> {
     // eat the opening brace
     let mut parsed_tokens = vec![tokens.last().unwrap().clone()];
     let t = tokens.last().unwrap().clone();
@@ -111,7 +111,7 @@ pub(super) fn parse_block(
     let end = *parsed_tokens.last().unwrap().span.end();
 
     Good(
-        BlockCodeExpr {
+        Block {
             code,
             returned_expr,
             span: start..=end,

--- a/zom_fe/src/parser/block.rs
+++ b/zom_fe/src/parser/block.rs
@@ -46,11 +46,10 @@ pub(super) fn parse_block(
         }
 
         let stmt = parse_try!(parse_statement, tokens, settings, context, parsed_tokens);
-        let semi = stmt.is_semi_need();
+        let is_eof = token_parteq!(tokens.last(), &EOF);
+        let semi = stmt.is_semi_need() && !is_eof;
 
-        // FIXME: Allow Binary operation in expression, in statements to allow `a = <expr>`..
-
-        if !token_parteq!(tokens.last(), &SemiColon)
+        if (!token_parteq!(tokens.last(), &SemiColon))
             && token_parteq!(tokens.last(), &CloseBrace)
             && match stmt.stmt {
                 Stmt::Expr(_) => true,
@@ -78,6 +77,8 @@ pub(super) fn parse_block(
                 // )))
                 err_et!(context, t, vec![SemiColon], t.tt)
             );
+        }else if is_eof {
+            break;
         }
     }
 
@@ -99,7 +100,7 @@ pub(super) fn parse_block(
                     context.source_file.clone(),
                     context.filename.clone(),
                 ),
-                format!("unclosed delimiter `}}`"),
+                "unclosed delimiter `}`".to_owned(),
                 false,
                 None,
                 vec![],

--- a/zom_fe/src/parser/expr.rs
+++ b/zom_fe/src/parser/expr.rs
@@ -13,7 +13,7 @@ use crate::parser::PartParsingResult::{Bad, Good, NotComplete};
 
 use crate::parser::PartParsingResult;
 
-use super::block::{parse_block_expr, BlockCodeExpr};
+use super::block::{parse_block_expr, Block};
 use super::{ParserSettings, ParsingContext};
 
 #[derive(PartialEq, Clone, Debug)]
@@ -34,7 +34,7 @@ pub enum Expr {
         rhs: Box<Expression>,
     },
     CallExpr(String, Vec<Expression>),
-    BlockExpr(BlockCodeExpr),
+    BlockExpr(Block),
 }
 
 impl Expression {

--- a/zom_fe/src/parser/function.rs
+++ b/zom_fe/src/parser/function.rs
@@ -7,7 +7,7 @@ use zom_common::token::Token;
 use crate::{err_et, expect_token, impl_span, parse_try, parser::types::parse_type};
 
 use super::{
-    block::{parse_block, BlockCodeExpr},
+    block::{parse_block, Block},
     types::Type,
     ASTNode, ParserSettings, ParsingContext, PartParsingResult,
 };
@@ -19,7 +19,7 @@ use zom_common::token::*;
 #[derive(PartialEq, Clone, Debug)]
 pub struct Function {
     pub prototype: Prototype,
-    pub body: Option<BlockCodeExpr>,
+    pub body: Option<Block>,
     pub span: RangeInclusive<usize>,
 }
 


### PR DESCRIPTION
In this PR:
* Add token End Of File
* Fix BlockCodeExpr Error when a closing brace is needed at this end of the file
* In crate `zom` replace anyhow errors with Error trait.
* Remove `log` & `pretty_env_logger` dependecies, unused
* Improve the panic hook : add a link to the issue tracker of this repository, like that it's simpler for the user to report an ICE.