### PR TITLE
replace RangeInclusive with Range

### DIFF
--- a/zom/src/ops/dev.rs
+++ b/zom/src/ops/dev.rs
@@ -26,7 +26,7 @@ pub fn dev() -> Result<ExitStatus, Box<dyn Error>> {
         path = PathBuf::from("example/test.zom");
     }
 
-    let buffer = "( ) { } [ ] ; : , @ % test".to_owned();
+    let buffer = "(){}[];:,@%test".to_owned();
     // fs::read_to_string(&path).expect("Should have been able to read the file");
 
     println!("file path = {}", path.display());

--- a/zom_common/src/error.rs
+++ b/zom_common/src/error.rs
@@ -5,7 +5,7 @@
 use super::{build_date, build_target_triple, commit_hash};
 use std::error::Error;
 use std::fmt::{self, Display};
-use std::ops::RangeInclusive;
+use std::ops::Range;
 use std::path::PathBuf;
 
 /// This function return spaces * len
@@ -76,14 +76,14 @@ impl Position {
     /// Can return `None` if the range's start position is greater that its end position.
     pub fn try_from_range(
         index: usize,
-        range: RangeInclusive<usize>,
+        range: Range<usize>,
         filetext: String,
         filename: PathBuf,
     ) -> Option<Position> {
         let mut line_start = 1;
         let mut col_start = 1;
         let mut line_end = 1;
-        let mut col_end = 1;
+        let mut col_end = 0;
 
         let mut range_start_found = false;
         let mut index_r = 0;
@@ -91,7 +91,7 @@ impl Position {
         for (idx, chr) in filetext.char_indices() {
             index_r = idx;
 
-            if *range.start() == idx {
+            if range.start == idx {
                 range_start_found = true;
             }
 
@@ -110,19 +110,19 @@ impl Position {
             match chr {
                 '\n' => {
                     line_end += 1;
-                    col_end = 1;
+                    col_end = 0;
                 }
                 _ => {
                     col_end += 1;
                 }
             }
 
-            if *range.end() == idx {
+            if range.end == idx {
                 break;
             }
         }
 
-        if index_r < *range.end() {
+        if index_r < range.end {
             // The range extends beyond the end of the input string.
             return None;
         }

--- a/zom_common/src/token.rs
+++ b/zom_common/src/token.rs
@@ -4,7 +4,8 @@
 
 use std::{
     fmt::{self, Display},
-    ops::RangeInclusive, str::FromStr,
+    ops::Range,
+    str::FromStr,
 };
 
 pub use TokenType::*;
@@ -184,7 +185,7 @@ impl FromStr for Operator {
             OP_LOGIC_NOT => Ok(LogicNot),
 
             OP_EQ => Ok(Equal),
-            op => Err(format!("unknown binary operator `{}`", op))
+            op => Err(format!("unknown binary operator `{}`", op)),
         }
     }
 }
@@ -266,11 +267,11 @@ pub const KW_IMPL: &str = "impl";
 pub struct Token {
     /// `tt` means token type.
     pub tt: TokenType,
-    pub span: RangeInclusive<usize>,
+    pub span: Range<usize>,
 }
 
 impl Token {
-    pub fn new(tt: TokenType, span: RangeInclusive<usize>) -> Token {
+    pub fn new(tt: TokenType, span: Range<usize>) -> Token {
         Token { tt, span }
     }
 }

--- a/zom_fe/src/parser.rs
+++ b/zom_fe/src/parser.rs
@@ -3,7 +3,7 @@
 //! It is entirely made for Zom, without using dependencies.
 
 use std::collections::HashMap;
-use std::ops::RangeInclusive;
+use std::ops::Range;
 
 use zom_common::error::ZomError;
 use zom_common::token::Token;
@@ -286,7 +286,7 @@ macro_rules! token_parteq(
 );
 
 pub trait CodeLocation {
-    fn span(&self) -> RangeInclusive<usize>;
+    fn span(&self) -> Range<usize>;
 }
 
 #[macro_export]
@@ -296,8 +296,8 @@ macro_rules! impl_span(
     );
     ($ast:ident, $span_field:ident) => (
         impl $crate::parser::CodeLocation for $ast {
-            fn span(&self) -> RangeInclusive<usize> {
-                self.span.clone()
+            fn span(&self) -> Range<usize> {
+                self.$span_field.clone()
             }
         }
     )

--- a/zom_fe/src/parser/block.rs
+++ b/zom_fe/src/parser/block.rs
@@ -1,4 +1,4 @@
-use std::ops::RangeInclusive;
+use std::ops::Range;
 
 use zom_common::token::{Token, TokenType::*};
 
@@ -20,7 +20,7 @@ use crate::parser::PartParsingResult::*;
 pub struct Block {
     pub code: Vec<Statement>,
     pub returned_expr: Option<Box<Expression>>,
-    pub span: RangeInclusive<usize>,
+    pub span: Range<usize>,
 }
 
 impl_span!(Block);
@@ -35,7 +35,7 @@ pub fn parse_block(
     let t = tokens.last().unwrap().clone();
     tokens.pop();
 
-    let start = *parsed_tokens.last().unwrap().span.start();
+    let start = parsed_tokens.last().unwrap().span.start;
 
     let mut code = vec![];
     let mut returned_expr: Option<Box<Expression>> = None;
@@ -95,13 +95,13 @@ pub fn parse_block(
         }
     );
 
-    let end = *parsed_tokens.last().unwrap().span.end();
+    let end = parsed_tokens.last().unwrap().span.end;
 
     Good(
         Block {
             code,
             returned_expr,
-            span: start..=end,
+            span: start..end,
         },
         parsed_tokens,
     )

--- a/zom_fe/src/parser/expr.rs
+++ b/zom_fe/src/parser/expr.rs
@@ -1,6 +1,6 @@
 //! This module contains the parsing for expressions.
 
-use std::ops::RangeInclusive;
+use std::ops::Range;
 
 use zom_common::token::Token;
 use zom_common::token::*;
@@ -19,7 +19,7 @@ use super::{ParserSettings, ParsingContext};
 #[derive(PartialEq, Clone, Debug)]
 pub struct Expression {
     pub expr: Expr,
-    pub span: RangeInclusive<usize>,
+    pub span: Range<usize>,
 }
 
 impl_span!(Expression);
@@ -88,15 +88,15 @@ pub fn parse_ident_expr(
         )
     );
 
-    let start = *parsed_tokens.last().unwrap().clone().span.start();
+    let start = parsed_tokens.last().unwrap().clone().span.start;
 
-    let end = *parsed_tokens.last().unwrap().clone().span.end();
+    let end = parsed_tokens.last().unwrap().clone().span.end;
 
     expect_token!(
         context,
         [OpenParen, OpenParen, ()]
         else {return Good(
-            Expression { expr: VariableExpr(name), span: start..=end },
+            Expression { expr: VariableExpr(name), span: start..end },
             parsed_tokens)}
         <= tokens, parsed_tokens);
 
@@ -122,12 +122,12 @@ pub fn parse_ident_expr(
         );
     }
 
-    let end = *parsed_tokens.last().unwrap().span.end();
+    let end = parsed_tokens.last().unwrap().span.end;
 
     Good(
         Expression {
             expr: CallExpr(name, args),
-            span: start..=end,
+            span: start..end,
         },
         parsed_tokens,
     )
@@ -147,14 +147,14 @@ pub fn parse_literal_expr(
         parsed_tokens,
         err_et!(context, t, vec![Int(0), Float(0.0)], t.tt)
     );
-    let start = *parsed_tokens.last().unwrap().span.start();
+    let start = parsed_tokens.last().unwrap().span.start;
 
-    let end = *parsed_tokens.last().unwrap().span.end();
+    let end = parsed_tokens.last().unwrap().span.end;
 
     Good(
         Expression {
             expr: LiteralExpr(value),
-            span: start..=end,
+            span: start..end,
         },
         parsed_tokens,
     )
@@ -292,7 +292,7 @@ pub fn parse_binary_expr(
                 lhs: Box::new(result),
                 rhs: Box::new(rhs.clone()),
             },
-            span: *lhs.span.start()..=*rhs.span.end(),
+            span: lhs.span.start..rhs.span.end,
         };
     }
 

--- a/zom_fe/src/parser/function.rs
+++ b/zom_fe/src/parser/function.rs
@@ -1,6 +1,6 @@
 //! This module parse function
 
-use std::{ops::RangeInclusive, str::FromStr};
+use std::{ops::Range, str::FromStr};
 
 use zom_common::token::{Str, Token};
 
@@ -22,9 +22,9 @@ use zom_common::error::{Position, ZomError};
 pub struct Function {
     abi: ABI,
     prototype: Prototype,
-    body: Option<Block>,
     return_ty: Type,
-    span: RangeInclusive<usize>,
+    body: Option<Block>,
+    span: Range<usize>,
 }
 
 impl_span!(Function);
@@ -64,7 +64,7 @@ impl FromStr for ABI {
 pub struct Arg {
     pub name: String,
     pub type_arg: Type,
-    pub span: RangeInclusive<usize>,
+    pub span: Range<usize>,
 }
 
 impl_span!(Arg);
@@ -73,7 +73,7 @@ impl_span!(Arg);
 pub struct Prototype {
     pub name: String,
     pub args: Vec<Arg>,
-    pub span: RangeInclusive<usize>,
+    pub span: Range<usize>,
 }
 
 impl_span!(Prototype);
@@ -87,7 +87,7 @@ pub fn parse_extern(
     let mut parsed_tokens = vec![tokens.last().unwrap().clone()];
     tokens.pop();
 
-    let start = *parsed_tokens.last().unwrap().span.start();
+    let start = parsed_tokens.last().unwrap().span.start;
 
     let t = tokens.last().unwrap().clone();
 
@@ -139,14 +139,14 @@ pub fn parse_extern(
         None
     };
 
-    let end = *parsed_tokens.last().unwrap().span.start();
+    let end = parsed_tokens.last().unwrap().span.start;
     Good(
         ASTNode::FunctionNode(Function {
             abi,
             prototype,
             body,
             return_ty,
-            span: start..=end,
+            span: start..end,
         }),
         parsed_tokens,
     )
@@ -161,7 +161,7 @@ pub fn parse_function(
     let mut parsed_tokens: Vec<Token> = vec![tokens.last().unwrap().clone()];
     tokens.pop();
 
-    let start = *parsed_tokens.last().unwrap().span.start();
+    let start = parsed_tokens.last().unwrap().span.start;
 
     let prototype = parse_try!(parse_prototype, tokens, settings, context, parsed_tokens);
 
@@ -169,14 +169,14 @@ pub fn parse_function(
 
     let body = parse_try!(parse_block, tokens, settings, context, parsed_tokens);
 
-    let end = *parsed_tokens.last().unwrap().span.end();
+    let end = parsed_tokens.last().unwrap().span.end;
     Good(
         ASTNode::FunctionNode(Function {
             abi: ABI::Zom,
             prototype,
             body: Some(body),
             return_ty,
-            span: start..=end,
+            span: start..end,
         }),
         parsed_tokens,
     )
@@ -197,7 +197,7 @@ pub fn parse_prototype(
         err_et!(context, t, vec![Ident(String::new())], t.tt)
     );
 
-    let start = *parsed_tokens.last().unwrap().span.start();
+    let start = parsed_tokens.last().unwrap().span.start;
     let t = tokens.last().unwrap().clone();
 
     expect_token!(
@@ -219,7 +219,7 @@ pub fn parse_prototype(
              parsed_tokens,
             err_et!(context, t, vec![Ident(String::new())], t.tt)
         );
-        let start = *parsed_tokens.last().unwrap().span.start();
+        let start = parsed_tokens.last().unwrap().span.start;
 
         let t = tokens.last().unwrap().clone();
         expect_token!(
@@ -229,12 +229,12 @@ pub fn parse_prototype(
             err_et!(context, t, vec![Colon], t.tt)
         );
         let type_arg = parse_try!(parse_type, tokens, settings, context, parsed_tokens);
-        let end = *parsed_tokens.last().unwrap().span.end();
+        let end = parsed_tokens.last().unwrap().span.end;
 
         args.push(Arg {
             name: name_arg,
             type_arg,
-            span: start..=end,
+            span: start..end,
         });
         let t = tokens.last().unwrap().clone();
 
@@ -248,13 +248,13 @@ pub fn parse_prototype(
         );
     }
 
-    let end = *parsed_tokens.last().unwrap().span.start();
+    let end = parsed_tokens.last().unwrap().span.start;
 
     Good(
         Prototype {
             name,
             args,
-            span: start..=end,
+            span: start..end,
         },
         parsed_tokens,
     )

--- a/zom_fe/src/parser/types.rs
+++ b/zom_fe/src/parser/types.rs
@@ -1,6 +1,6 @@
 //! This module is responsible for the parsing of types.
 
-use std::ops::RangeInclusive;
+use std::ops::Range;
 
 use zom_common::token::Token;
 
@@ -15,7 +15,7 @@ use zom_common::token::*;
 #[derive(PartialEq, Clone, Debug)]
 pub struct Type {
     pub type_variant: TypeVariant,
-    pub span: RangeInclusive<usize>,
+    pub span: Range<usize>,
 }
 
 impl_span!(Type);


### PR DESCRIPTION
In this PR, we replace every 'RangeInclusive' with 'Range' as described in some commit messages, the lexer can only provide non inclusive ranges and we store everywhere inclusive ranges, so every time subtract one from the end is ugly and use non-inclusive ranges is better in some cases.